### PR TITLE
modify rounds state icons

### DIFF
--- a/src/components/Round.tsx
+++ b/src/components/Round.tsx
@@ -1,5 +1,6 @@
-import SolvedIcon from '@mui/icons-material/CheckRounded'
-import UnsolvedIcon from '@mui/icons-material/CloseRounded'
+import SolvedIcon from '@mui/icons-material/CheckBoxRounded'
+import UnsolvedIcon from '@mui/icons-material/DisabledByDefaultRounded'
+import BlankBoxIcon from '@mui/icons-material/CheckBoxOutlineBlankRounded'
 import DeleteIcon from '@mui/icons-material/UndoRounded'
 import Box from '@mui/material/Box'
 import Button from '@mui/material/Button'
@@ -102,29 +103,16 @@ const Round: FC<Props> = ({ round, index }) => {
                     }}
                   >
                     <SingleCharLabel>{query.verifier}</SingleCharLabel>
-                    <Box pt={1} pb={2} position="relative">
-                      <Box
-                        height={20}
-                        margin="auto"
-                        width={20}
-                        sx={{
-                          borderWidth: 2,
-                          borderStyle: 'solid',
-                          borderColor: theme.palette.primary.main,
-                          borderRadius: theme.spacing(0.5),
-                        }}
-                      />
-                      <Box
-                        position="absolute"
-                        top={-2}
-                        left={3}
-                        sx={{ color: theme.palette.text.primary }}
-                      >
+                    <Box position="relative">
+                      <Box>
+                        {query.state === 'unknown' && (
+                          <BlankBoxIcon sx={{ color: theme.palette.primary.main }} />
+                        )}
                         {query.state === 'solved' && (
-                          <SolvedIcon fontSize="large" />
+                          <SolvedIcon sx={{ color: theme.palette.primary.dark }} />
                         )}
                         {query.state === 'unsolved' && (
-                          <UnsolvedIcon fontSize="large" />
+                          <UnsolvedIcon sx={{ color: theme.palette.secondary.dark }} />
                         )}
                       </Box>
                     </Box>


### PR DESCRIPTION
Instead of a plain check mark or cross now it uses boxed icons with matching symbols.
The unknown state has been converted from a div with border to an empty box icon.
Instead of showing the state in black it uses primary.dark (green) and secondary.dark (red) as color for the state.

![turingmachine_rouds_ui](https://github.com/zyle87/turing-machine-interactive-sheet/assets/63302676/ef14b782-f372-4245-b0fd-07aa18c39190)
